### PR TITLE
test: update test syntax, add tuple

### DIFF
--- a/src/_pymmcore_nano.cc
+++ b/src/_pymmcore_nano.cc
@@ -1,8 +1,8 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/string.h>
-#include <nanobind/stl/vector.h>
 #include <nanobind/stl/tuple.h>
+#include <nanobind/stl/vector.h>
 
 #include "MMCore.h"
 #include "MMEventCallback.h"

--- a/src/_pymmcore_nano.cc
+++ b/src/_pymmcore_nano.cc
@@ -2,6 +2,7 @@
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
+#include <nanobind/stl/tuple.h>
 
 #include "MMCore.h"
 #include "MMEventCallback.h"


### PR DESCRIPTION
This unskips the getROI test, and cleans up test syntax slightly