### PR TITLE
fix: fix core callback polymorphism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BUILDDIR := $(shell ls -d build/cp3* 2>/dev/null | head -n 1)
 
-.PHONY: build clean install test coverage stubs check
+.PHONY: build clean install test coverage stubs check clean-cov
 
 # https://mesonbuild.com/meson-python/how-to-guides/editable-installs.html
 # editable install
@@ -42,6 +42,9 @@ clean:
 	rm -rf .ruff_cache .mypy_cache .pytest_cache
 	rm -rf .mesonpy-*
 	rm -rf *.gcov
+
+clean-cov:
+	find $(BUILDDIR) -name "*.gcda" -exec rm -f {} \;
 
 coverage:
 	rm -rf coverage coverage.xml coverage_cpp.xml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import sys
+import pytest
+import pymmcore_nano as pmn
+
+
+@pytest.fixture
+def adapter_paths() -> list[str]:
+    adapters = Path(__file__).parent / "adapters" / sys.platform
+    if not adapters.is_dir():
+        pytest.skip(f"No adapters for {sys.platform}")
+    return [str(adapters)]
+
+
+@pytest.fixture
+def core(adapter_paths: list[str]) -> pmn.CMMCore:
+    """Return a CMMCore instance with the demo configuration loaded."""
+    mmc = pmn.CMMCore()
+    mmc.setDeviceAdapterSearchPaths(adapter_paths)
+    return mmc
+
+
+@pytest.fixture
+def demo_config() -> Path:
+    return Path(__file__).parent / "MMConfig_demo.cfg"
+
+
+@pytest.fixture
+def demo_core(core: pmn.CMMCore, demo_config: Path) -> pmn.CMMCore:
+    """Return a CMMCore instance with the demo configuration loaded."""
+    core.loadSystemConfiguration(demo_config)
+    return core

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,88 @@
+from unittest.mock import Mock, call
+import pymmcore_nano as pmn
+from pathlib import Path
+
+
+def test_callback(core: pmn.CMMCore, demo_config: Path):
+    """Test that the callback is called."""
+
+    mock = Mock()
+
+    class MyCallback(pmn.MMEventCallback):
+        def onPropertiesChanged(self) -> None:
+            mock("onPropertiesChanged")
+
+        def onPropertyChanged(self, *args) -> None:
+            mock("onPropertyChanged")
+
+        def onChannelGroupChanged(self, *args) -> None:
+            mock("onChannelGroupChanged")
+
+        def onConfigGroupChanged(self, *args) -> None:
+            mock("onConfigGroupChanged")
+
+        def onSystemConfigurationLoaded(self) -> None:
+            mock("onSystemConfigurationLoaded")
+
+        def onPixelSizeChanged(self, *args) -> None:
+            mock("onPixelSizeChanged")
+
+        def onPixelSizeAffineChanged(self, *args) -> None:
+            mock("onPixelSizeAffineChanged")
+
+        def onSLMExposureChanged(self, *args) -> None:
+            mock("onSLMExposureChanged")
+
+        def onExposureChanged(self, *args) -> None:
+            mock("onExposureChanged")
+
+        def onStagePositionChanged(self, *args) -> None:
+            mock("onStagePositionChanged")
+
+        def onXYStagePositionChanged(self, *args) -> None:
+            mock("onXYStagePositionChanged")
+
+    cb = MyCallback()
+    core.registerCallback(cb)
+
+    core.loadSystemConfiguration(demo_config)
+    mock.assert_called_with("onSystemConfigurationLoaded")
+
+    mock.reset_mock()
+    core.setProperty("Camera", "Binning", "2")
+    mock.assert_has_calls(
+        [
+            call("onPropertyChanged"),
+            call("onConfigGroupChanged"),
+        ]
+    )
+
+    core.setProperty("Camera", "ScanMode", "2")
+    mock.assert_has_calls([call("onPropertiesChanged")])
+
+    core.setChannelGroup("LightPath")
+    mock.assert_called_with("onChannelGroupChanged")
+
+    resgroup = core.getAvailablePixelSizeConfigs()[1]
+    core.setPixelSizeConfig(resgroup)
+    mock.assert_has_calls(
+        [
+            call("onConfigGroupChanged"),
+            call("onPixelSizeAffineChanged"),
+            call("onPixelSizeChanged"),
+        ]
+    )
+
+    if dev := core.getSLMDevice():
+        core.setSLMExposure(dev, 10)
+        mock.assert_called_with("onSLMExposureChanged")
+
+    core.setExposure(10)
+    mock.assert_called_with("onExposureChanged")
+
+    mock.reset_mock()
+    core.setPosition(12)
+    mock.assert_called_with("onStagePositionChanged")
+
+    core.setXYPosition(1, 2)
+    mock.assert_called_with("onXYStagePositionChanged")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,5 @@
 import enum
 from pathlib import Path
-import sys
 import time
 from typing import Callable
 import numpy as np
@@ -15,31 +14,6 @@ def _wait_until(predicate: Callable[[], bool], timeout: float = 1.0, interval=0.
             return True
         time.sleep(interval)
     raise TimeoutError("Timed out waiting for condition")
-
-
-@pytest.fixture
-def adapter_paths() -> list[str]:
-    adapters = Path(__file__).parent / "adapters" / sys.platform
-    if not adapters.is_dir():
-        pytest.skip(f"No adapters for {sys.platform}")
-    return [str(adapters)]
-
-
-@pytest.fixture
-def core(adapter_paths: list[str]) -> pmn.CMMCore:
-    """Return a CMMCore instance with the demo configuration loaded."""
-    mmc = pmn.CMMCore()
-    mmc.setDeviceAdapterSearchPaths(adapter_paths)
-    return mmc
-
-
-@pytest.fixture
-def demo_core(core: pmn.CMMCore) -> pmn.CMMCore:
-    """Return a CMMCore instance with the demo configuration loaded."""
-    cfg = Path(__file__).parent / "MMConfig_demo.cfg"
-    core.loadSystemConfiguration(cfg)
-    core.waitForSystem()
-    return core
 
 
 def test_enums() -> None:
@@ -109,6 +83,7 @@ def test_device_loading(core: pmn.CMMCore) -> None:
 
     core.loadDevice(LABEL, LIBRARY, DEVICE_NAME)
     core.initializeAllDevices()
+    core.waitForSystem()
     init_state = core.getDeviceInitializationState(LABEL)
     assert init_state == pmn.DeviceInitializationState.InitializedSuccessfully
     core.unloadAllDevices()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -26,8 +26,6 @@ def test_enums() -> None:
 def test_bare_core() -> None:
     """Test basic CMMCore functionality without providing any adapters."""
     mmc = pmn.CMMCore()
-    mmc.setDeviceAdapterSearchPaths([])
-    assert not mmc.getDeviceAdapterSearchPaths()
 
     api_version_info = mmc.getAPIVersionInfo()
     assert api_version_info.startswith("Device API version")
@@ -38,9 +36,6 @@ def test_bare_core() -> None:
     assert timeout > 0
     mmc.setTimeoutMs(1000)
     assert mmc.getTimeoutMs() == 1000
-
-    with pytest.raises(Exception):
-        mmc.loadDevice("Camera", "DemoCamera", "DCam")
 
 
 def test_device_listings(core: pmn.CMMCore) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -26,6 +26,9 @@ def test_enums() -> None:
 def test_bare_core() -> None:
     """Test basic CMMCore functionality without providing any adapters."""
     mmc = pmn.CMMCore()
+    mmc.setDeviceAdapterSearchPaths([])
+    assert not mmc.getDeviceAdapterSearchPaths()
+
     api_version_info = mmc.getAPIVersionInfo()
     assert api_version_info.startswith("Device API version")
     assert str(pmn.DEVICE_INTERFACE_VERSION) in api_version_info

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -39,7 +39,7 @@ def test_bare_core() -> None:
     mmc.setTimeoutMs(1000)
     assert mmc.getTimeoutMs() == 1000
 
-    with pytest.raises(pmn.CMMError):
+    with pytest.raises(Exception):
         mmc.loadDevice("Camera", "DemoCamera", "DCam")
 
 


### PR DESCRIPTION
MMEventCallback wasn't polymorphic... meaning python subclasses weren't getting their virtual method overrides called correctly.  This fixes that