### PR TITLE
feat: compatibility with pymmcore-plus

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,10 @@ repos:
     rev: v19.1.4
     hooks:
       - id: clang-format
-        args: ["--style={ BasedOnStyle: Google, ColumnLimit: 99 }", -i]
+        args: ["--style={ BasedOnStyle: Google, ColumnLimit: 96 }", -i]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.0
+    rev: v0.8.1
     hooks:
       - id: ruff
         args: [--fix]

--- a/meson.build
+++ b/meson.build
@@ -40,7 +40,7 @@ run_command(py.full_path(), 'scripts/patch_sources.py', check: true)
 
 # --------------------------
 
-cpp_args = ['-DMMDEVICE_CLIENT_BUILD']
+cpp_args = ['-DMMDEVICE_CLIENT_BUILD', '-DMATCH_SWIG']
 
 if host_machine.system() == 'windows'
     cpp_args += ['-DNOMINMAX', '-D_CRT_SECURE_NO_WARNINGS']

--- a/meson.build
+++ b/meson.build
@@ -52,7 +52,7 @@ ext_module = py.extension_module(
     dependencies: [nanobind_dep],
     include_directories: include_dirs,
     install: true,
-    cpp_args: cpp_args,
+    cpp_args: cpp_args + ['-DNB_DOMAIN=pmn'],
 )
 
 # Create stubs using nanobind.stubgen

--- a/src/_pymmcore_nano.cc
+++ b/src/_pymmcore_nano.cc
@@ -18,7 +18,8 @@ using namespace nb::literals;
 using ro_np_array = nb::ndarray<nb::numpy, nb::ro>;
 
 // Helper to determine dtype and shape
-std::pair<nb::dlpack::dtype, std::vector<size_t>> get_dtype_shape(unsigned height, unsigned width,
+std::pair<nb::dlpack::dtype, std::vector<size_t>> get_dtype_shape(unsigned height,
+                                                                  unsigned width,
                                                                   unsigned bytesPerPixel,
                                                                   unsigned numComponents = 1) {
   // Calculate dtype and shape
@@ -46,9 +47,10 @@ std::pair<nb::dlpack::dtype, std::vector<size_t>> get_dtype_shape(unsigned heigh
       throw std::runtime_error("Unsupported bytesPerPixel.");
   }
 }
-// Overload to determine dtype and shape from pixelType, which appears in image metadata
-std::pair<nb::dlpack::dtype, std::vector<size_t>> get_dtype_shape(unsigned height, unsigned width,
-                                                                  const std::string& pixelType) {
+// Overload to determine dtype and shape from pixelType, which appears in image
+// metadata
+std::pair<nb::dlpack::dtype, std::vector<size_t>> get_dtype_shape(
+    unsigned height, unsigned width, const std::string &pixelType) {
   // These values are hard-coded in CircularBuffer.cpp
   if (pixelType == "GRAY8") {
     return {nb::dtype<uint8_t>(), {height, width}};
@@ -66,26 +68,29 @@ std::pair<nb::dlpack::dtype, std::vector<size_t>> get_dtype_shape(unsigned heigh
 }
 
 /**
- * @brief Creates a read-only NumPy array representing an image from the provided buffer and
- * `CMMCore` instance.
+ * @brief Creates a read-only NumPy array representing an image from the
+ * provided buffer and `CMMCore` instance.
  *
- * This function wraps a raw memory buffer from a `CMMCore` instance into a `nanobind::ndarray` of
- * type `numpy.ndarray`. The array is read-only and shares ownership with the provided `CMMCore`
- * instance to ensure memory safety.
+ * This function wraps a raw memory buffer from a `CMMCore` instance into a
+ * `nanobind::ndarray` of type `numpy.ndarray`. The array is read-only and
+ * shares ownership with the provided `CMMCore` instance to ensure memory
+ * safety.
  *
- * @param core A reference to the `CMMCore` object, which provides image metadata and ensures
- *             ownership of the buffer.
+ * @param core A reference to the `CMMCore` object, which provides image
+ * metadata and ensures ownership of the buffer.
  * @param pBuf Pointer to the data buffer containing the image data.
  *
- * @return A `nanobind::ndarray` representing the image buffer as a `numpy.ndarray`.
+ * @return A `nanobind::ndarray` representing the image buffer as a
+ * `numpy.ndarray`.
  *
- * @throws std::runtime_error If the combination of image properties (e.g., bytes per pixel, number
- *                            of components) is not supported.
+ * @throws std::runtime_error If the combination of image properties (e.g.,
+ * bytes per pixel, number of components) is not supported.
  *
- * @note The resulting array is C-contiguous by default, as no strides are specified.
- *       Ownership of the buffer is tied to the lifetime of the `CMMCore` object.
+ * @note The resulting array is C-contiguous by default, as no strides are
+ * specified. Ownership of the buffer is tied to the lifetime of the `CMMCore`
+ * object.
  */
-ro_np_array create_image_array(CMMCore& core, void* pBuf) {
+ro_np_array create_image_array(CMMCore &core, void *pBuf) {
   // Retrieve image properties
   unsigned width = core.getImageWidth();
   unsigned height = core.getImageHeight();
@@ -107,26 +112,29 @@ ro_np_array create_image_array(CMMCore& core, void* pBuf) {
   );
 }
 /**
- * @brief Creates a read-only NumPy array representing image metadata from the provided buffer and
- * `CMMCore` instance.
+ * @brief Creates a read-only NumPy array representing image metadata from the
+ * provided buffer and `CMMCore` instance.
  *
- * This function wraps a raw memory buffer from a `CMMCore` instance into a `nanobind::ndarray` of
- * type `numpy.ndarray`. The array is read-only and shares ownership with the provided `CMMCore`
- * instance to ensure memory safety.
+ * This function wraps a raw memory buffer from a `CMMCore` instance into a
+ * `nanobind::ndarray` of type `numpy.ndarray`. The array is read-only and
+ * shares ownership with the provided `CMMCore` instance to ensure memory
+ * safety.
  *
- * @param core A reference to the `CMMCore` object, which provides image metadata and ensures
- *            ownership of the buffer.
+ * @param core A reference to the `CMMCore` object, which provides image
+ * metadata and ensures ownership of the buffer.
  * @param pBuf Pointer to the data buffer containing the image metadata.
  * @param md The metadata object containing the image properties.
  *
- * @return A `nanobind::ndarray` representing the image metadata buffer as a `numpy.ndarray`.
+ * @return A `nanobind::ndarray` representing the image metadata buffer as a
+ * `numpy.ndarray`.
  *
- * @throws std::runtime_error If the combination of image properties (e.g., bytes per pixel, number
- *                          of components) is not supported.
+ * @throws std::runtime_error If the combination of image properties (e.g.,
+ * bytes per pixel, number of components) is not supported.
  *
- * @note The resulting array is C-contiguous by default, as no strides are specified.
+ * @note The resulting array is C-contiguous by default, as no strides are
+ * specified.
  */
-ro_np_array create_metadata_array(CMMCore& core, void* pBuf, const Metadata md) {
+ro_np_array create_metadata_array(CMMCore &core, void *pBuf, const Metadata md) {
   // These keys are unfortunately hard-coded in the source code
   // see https://github.com/micro-manager/mmCoreAndDevices/pull/531
   // Retrieve and log the values of the tags
@@ -154,19 +162,21 @@ ro_np_array create_metadata_array(CMMCore& core, void* pBuf, const Metadata md) 
 
 class PyMMEventCallback : public MMEventCallback {
  public:
-  NB_TRAMPOLINE(MMEventCallback, 11);  // Total number of overridable virtual methods.
+  NB_TRAMPOLINE(MMEventCallback,
+                11);  // Total number of overridable virtual methods.
 
   void onPropertiesChanged() override { NB_OVERRIDE(onPropertiesChanged); }
 
-  void onPropertyChanged(const char* name, const char* propName, const char* propValue) override {
+  void onPropertyChanged(const char *name, const char *propName,
+                         const char *propValue) override {
     NB_OVERRIDE(onPropertyChanged, name, propName, propValue);
   }
 
-  void onChannelGroupChanged(const char* newChannelGroupName) override {
+  void onChannelGroupChanged(const char *newChannelGroupName) override {
     NB_OVERRIDE(onChannelGroupChanged, newChannelGroupName);
   }
 
-  void onConfigGroupChanged(const char* groupName, const char* newConfigName) override {
+  void onConfigGroupChanged(const char *groupName, const char *newConfigName) override {
     NB_OVERRIDE(onConfigGroupChanged, groupName, newConfigName);
   }
 
@@ -181,19 +191,19 @@ class PyMMEventCallback : public MMEventCallback {
     NB_OVERRIDE(onPixelSizeAffineChanged, v0, v1, v2, v3, v4, v5);
   }
 
-  void onStagePositionChanged(char* name, double pos) override {
+  void onStagePositionChanged(char *name, double pos) override {
     NB_OVERRIDE(onStagePositionChanged, name, pos);
   }
 
-  void onXYStagePositionChanged(char* name, double xpos, double ypos) override {
+  void onXYStagePositionChanged(char *name, double xpos, double ypos) override {
     NB_OVERRIDE(onXYStagePositionChanged, name, xpos, ypos);
   }
 
-  void onExposureChanged(char* name, double newExposure) override {
+  void onExposureChanged(char *name, double newExposure) override {
     NB_OVERRIDE(onExposureChanged, name, newExposure);
   }
 
-  void onSLMExposureChanged(char* name, double newExposure) override {
+  void onSLMExposureChanged(char *name, double newExposure) override {
     NB_OVERRIDE(onSLMExposureChanged, name, newExposure);
   }
 };
@@ -340,25 +350,6 @@ NB_MODULE(_pymmcore_nano, m) {
   /////////////////// Enums ///////////////////
 
   nb::enum_<MM::DeviceType>(m, "DeviceType", nb::is_arithmetic())
-      // aliases
-      //  .value("Unknown", MM::DeviceType::UnknownType)
-      //  .value("Any", MM::DeviceType::AnyType)
-      //  .value("Camera", MM::DeviceType::CameraDevice)
-      //  .value("Shutter", MM::DeviceType::ShutterDevice)
-      //  .value("State", MM::DeviceType::StateDevice)
-      //  .value("Stage", MM::DeviceType::StageDevice)
-      //  .value("XYStage", MM::DeviceType::XYStageDevice)
-      //  .value("Serial", MM::DeviceType::SerialDevice)
-      //  .value("Generic", MM::DeviceType::GenericDevice)
-      //  .value("AutoFocus", MM::DeviceType::AutoFocusDevice)
-      //  .value("Core", MM::DeviceType::CoreDevice)
-      //  .value("ImageProcessor", MM::DeviceType::ImageProcessorDevice)
-      //  .value("SignalIO", MM::DeviceType::SignalIODevice)
-      //  .value("Magnifier", MM::DeviceType::MagnifierDevice)
-      //  .value("SLM", MM::DeviceType::SLMDevice)
-      //  .value("Hub", MM::DeviceType::HubDevice)
-      //  .value("Galvo", MM::DeviceType::GalvoDevice)
-      // actual values
       .value("UnknownType", MM::DeviceType::UnknownType)
       .value("AnyType", MM::DeviceType::AnyType)
       .value("CameraDevice", MM::DeviceType::CameraDevice)
@@ -393,19 +384,12 @@ NB_MODULE(_pymmcore_nano, m) {
       .value("StopSequence", MM::ActionType::StopSequence);
 
   nb::enum_<MM::PortType>(m, "PortType", nb::is_arithmetic())
-      //  .value("Invalid", MM::PortType::InvalidPort)
-      //  .value("Serial", MM::PortType::SerialPort)
-      //  .value("USB", MM::PortType::USBPort)
-      //  .value("HID", MM::PortType::HIDPort)
       .value("InvalidPort", MM::PortType::InvalidPort)
       .value("SerialPort", MM::PortType::SerialPort)
       .value("USBPort", MM::PortType::USBPort)
       .value("HIDPort", MM::PortType::HIDPort);
 
   nb::enum_<MM::FocusDirection>(m, "FocusDirection", nb::is_arithmetic())
-      //  .value("Unknown", MM::FocusDirection::FocusDirectionUnknown)
-      //  .value("TowardSample", MM::FocusDirection::FocusDirectionTowardSample)
-      //  .value("AwayFromSample", MM::FocusDirection::FocusDirectionAwayFromSample)
       .value("FocusDirectionUnknown", MM::FocusDirection::FocusDirectionUnknown)
       .value("FocusDirectionTowardSample", MM::FocusDirection::FocusDirectionTowardSample)
       .value("FocusDirectionAwayFromSample", MM::FocusDirection::FocusDirectionAwayFromSample);
@@ -426,6 +410,69 @@ NB_MODULE(_pymmcore_nano, m) {
       .value("InitializedSuccessfully", DeviceInitializationState::InitializedSuccessfully)
       .value("InitializationFailed", DeviceInitializationState::InitializationFailed);
 
+// the SWIG wrapper doesn't create enums, it puts them all in the top level
+// so for backwards compatibility we define them here as well
+#ifdef MATCH_SWIG
+
+  m.attr("UnknownType") = static_cast<int>(MM::DeviceType::UnknownType);
+  m.attr("AnyType") = static_cast<int>(MM::DeviceType::AnyType);
+  m.attr("CameraDevice") = static_cast<int>(MM::DeviceType::CameraDevice);
+  m.attr("ShutterDevice") = static_cast<int>(MM::DeviceType::ShutterDevice);
+  m.attr("StateDevice") = static_cast<int>(MM::DeviceType::StateDevice);
+  m.attr("StageDevice") = static_cast<int>(MM::DeviceType::StageDevice);
+  m.attr("XYStageDevice") = static_cast<int>(MM::DeviceType::XYStageDevice);
+  m.attr("SerialDevice") = static_cast<int>(MM::DeviceType::SerialDevice);
+  m.attr("GenericDevice") = static_cast<int>(MM::DeviceType::GenericDevice);
+  m.attr("AutoFocusDevice") = static_cast<int>(MM::DeviceType::AutoFocusDevice);
+  m.attr("CoreDevice") = static_cast<int>(MM::DeviceType::CoreDevice);
+  m.attr("ImageProcessorDevice") = static_cast<int>(MM::DeviceType::ImageProcessorDevice);
+  m.attr("SignalIODevice") = static_cast<int>(MM::DeviceType::SignalIODevice);
+  m.attr("MagnifierDevice") = static_cast<int>(MM::DeviceType::MagnifierDevice);
+  m.attr("SLMDevice") = static_cast<int>(MM::DeviceType::SLMDevice);
+  m.attr("HubDevice") = static_cast<int>(MM::DeviceType::HubDevice);
+  m.attr("GalvoDevice") = static_cast<int>(MM::DeviceType::GalvoDevice);
+
+  m.attr("Undef") = static_cast<int>(MM::PropertyType::Undef);
+  m.attr("String") = static_cast<int>(MM::PropertyType::String);
+  m.attr("Float") = static_cast<int>(MM::PropertyType::Float);
+  m.attr("Integer") = static_cast<int>(MM::PropertyType::Integer);
+
+  m.attr("NoAction") = static_cast<int>(MM::ActionType::NoAction);
+  m.attr("BeforeGet") = static_cast<int>(MM::ActionType::BeforeGet);
+  m.attr("AfterSet") = static_cast<int>(MM::ActionType::AfterSet);
+  m.attr("IsSequenceable") = static_cast<int>(MM::ActionType::IsSequenceable);
+  m.attr("AfterLoadSequence") = static_cast<int>(MM::ActionType::AfterLoadSequence);
+  m.attr("StartSequence") = static_cast<int>(MM::ActionType::StartSequence);
+  m.attr("StopSequence") = static_cast<int>(MM::ActionType::StopSequence);
+
+  m.attr("InvalidPort") = static_cast<int>(MM::PortType::InvalidPort);
+  m.attr("SerialPort") = static_cast<int>(MM::PortType::SerialPort);
+  m.attr("USBPort") = static_cast<int>(MM::PortType::USBPort);
+  m.attr("HIDPort") = static_cast<int>(MM::PortType::HIDPort);
+
+  m.attr("FocusDirectionUnknown") = static_cast<int>(MM::FocusDirection::FocusDirectionUnknown);
+  m.attr("FocusDirectionTowardSample") =
+      static_cast<int>(MM::FocusDirection::FocusDirectionTowardSample);
+  m.attr("FocusDirectionAwayFromSample") =
+      static_cast<int>(MM::FocusDirection::FocusDirectionAwayFromSample);
+
+  m.attr("Attention") = static_cast<int>(MM::DeviceNotification::Attention);
+  m.attr("Done") = static_cast<int>(MM::DeviceNotification::Done);
+  m.attr("StatusChanged") = static_cast<int>(MM::DeviceNotification::StatusChanged);
+
+  m.attr("Unimplemented") = static_cast<int>(MM::DeviceDetectionStatus::Unimplemented);
+  m.attr("Misconfigured") = static_cast<int>(MM::DeviceDetectionStatus::Misconfigured);
+  m.attr("CanNotCommunicate") = static_cast<int>(MM::DeviceDetectionStatus::CanNotCommunicate);
+  m.attr("CanCommunicate") = static_cast<int>(MM::DeviceDetectionStatus::CanCommunicate);
+
+  m.attr("Uninitialized") = static_cast<int>(DeviceInitializationState::Uninitialized);
+  m.attr("InitializedSuccessfully") =
+      static_cast<int>(DeviceInitializationState::InitializedSuccessfully);
+  m.attr("InitializationFailed") =
+      static_cast<int>(DeviceInitializationState::InitializationFailed);
+
+#endif
+
   //////////////////// Supporting classes ////////////////////
 
   nb::class_<Configuration>(m, "Configuration")
@@ -434,16 +481,19 @@ NB_MODULE(_pymmcore_nano, m) {
       .def("deleteSetting", &Configuration::deleteSetting, "device"_a, "property"_a)
       .def("isPropertyIncluded", &Configuration::isPropertyIncluded, "device"_a, "property"_a)
       .def("isConfigurationIncluded", &Configuration::isConfigurationIncluded, "cfg"_a)
+      .def("isSettingIncluded", &Configuration::isSettingIncluded, "setting"_a)
       .def("getSetting", nb::overload_cast<size_t>(&Configuration::getSetting, nb::const_),
            "index"_a)
-      .def("getSetting", nb::overload_cast<const char*, const char*>(&Configuration::getSetting),
+      .def("getSetting",
+           nb::overload_cast<const char *, const char *>(&Configuration::getSetting),
            "device"_a, "property"_a)
       .def("size", &Configuration::size)
       .def("getVerbose", &Configuration::getVerbose);
 
   nb::class_<PropertySetting>(m, "PropertySetting")
-      .def(nb::init<const char*, const char*, const char*, bool>(), "deviceLabel"_a, "prop"_a,
-           "value"_a, "readOnly"_a = false, "Constructor specifying the entire contents")
+      .def(nb::init<const char *, const char *, const char *, bool>(), "deviceLabel"_a,
+           "prop"_a, "value"_a, "readOnly"_a = false,
+           "Constructor specifying the entire contents")
       .def(nb::init<>(), "Default constructor")
       .def("getDeviceLabel", &PropertySetting::getDeviceLabel, "Returns the device label")
       .def("getPropertyName", &PropertySetting::getPropertyName, "Returns the property name")
@@ -458,7 +508,7 @@ NB_MODULE(_pymmcore_nano, m) {
 
   nb::class_<Metadata>(m, "Metadata")
       .def(nb::init<>(), "Empty constructor")
-      .def(nb::init<const Metadata&>(), "Copy constructor")
+      .def(nb::init<const Metadata &>(), "Copy constructor")
       // Member functions
       .def("Clear", &Metadata::Clear, "Clears all tags")
       .def("GetKeys", &Metadata::GetKeys, "Returns all tag keys")
@@ -469,18 +519,20 @@ NB_MODULE(_pymmcore_nano, m) {
       .def("RemoveTag", &Metadata::RemoveTag, "key"_a, "Removes a tag by key")
       .def("Merge", &Metadata::Merge, "newTags"_a, "Merges new tags into the metadata")
       .def("Serialize", &Metadata::Serialize, "Serializes the metadata")
-      .def("Restore", &Metadata::Restore, "stream"_a, "Restores metadata from a serialized string")
+      .def("Restore", &Metadata::Restore, "stream"_a,
+           "Restores metadata from a serialized string")
       .def("Dump", &Metadata::Dump, "Dumps metadata in human-readable format")
-      // Template methods (bound using lambdas due to C++ template limitations in bindings)
+      // Template methods (bound using lambdas due to C++ template limitations
+      // in bindings)
       .def(
           "PutTag",
-          [](Metadata& self, const std::string& key, const std::string& deviceLabel,
-             const std::string& value) { self.PutTag(key, deviceLabel, value); },
+          [](Metadata &self, const std::string &key, const std::string &deviceLabel,
+             const std::string &value) { self.PutTag(key, deviceLabel, value); },
           "key"_a, "deviceLabel"_a, "value"_a, "Adds a MetadataSingleTag")
 
       .def(
           "PutImageTag",
-          [](Metadata& self, const std::string& key, const std::string& value) {
+          [](Metadata &self, const std::string &key, const std::string &value) {
             self.PutImageTag(key, value);
           },
           "key"_a, "value"_a, "Adds an image tag");
@@ -496,14 +548,17 @@ NB_MODULE(_pymmcore_nano, m) {
       .def("SetName", &MetadataTag::SetName, "name"_a, "Sets the name of the tag")
       .def("SetReadOnly", &MetadataTag::SetReadOnly, "readOnly"_a, "Sets the read-only status")
       // Virtual functions
-      .def("ToSingleTag", &MetadataTag::ToSingleTag, "Converts to MetadataSingleTag if applicable")
+      .def("ToSingleTag", &MetadataTag::ToSingleTag,
+           "Converts to MetadataSingleTag if applicable")
       .def("ToArrayTag", &MetadataTag::ToArrayTag, "Converts to MetadataArrayTag if applicable")
       .def("Clone", &MetadataTag::Clone, "Creates a clone of the MetadataTag")
       .def("Serialize", &MetadataTag::Serialize, "Serializes the MetadataTag to a string")
-      .def("Restore", nb::overload_cast<const char*>(&MetadataTag::Restore), "stream"_a,
+      .def("Restore", nb::overload_cast<const char *>(&MetadataTag::Restore), "stream"_a,
            "Restores from a serialized string");
-  // Ommitting the std::istringstream& overload: Python doesn't have a stringstream equivalent
-  //  .def("Restore", nb::overload_cast<std::istringstream&>(&MetadataTag::Restore),
+  // Ommitting the std::istringstream& overload: Python doesn't have a
+  // stringstream equivalent
+  //  .def("Restore",
+  //  nb::overload_cast<std::istringstream&>(&MetadataTag::Restore),
   //  "istream"_a,
   //       "Restores from an input stream")
   // Static methods
@@ -512,7 +567,7 @@ NB_MODULE(_pymmcore_nano, m) {
 
   nb::class_<MetadataSingleTag, MetadataTag>(m, "MetadataSingleTag")
       .def(nb::init<>(), "Default constructor")
-      .def(nb::init<const char*, const char*, bool>(), "name"_a, "device"_a, "readOnly"_a,
+      .def(nb::init<const char *, const char *, bool>(), "name"_a, "device"_a, "readOnly"_a,
            "Parameterized constructor")
       // Member functions
       .def("GetValue", &MetadataSingleTag::GetValue, "Returns the value")
@@ -521,17 +576,20 @@ NB_MODULE(_pymmcore_nano, m) {
            "Returns this object as MetadataSingleTag")
       .def("Clone", &MetadataSingleTag::Clone, "Clones this tag")
       .def("Serialize", &MetadataSingleTag::Serialize, "Serializes this tag to a string")
-      // Omitting the std::istringstream& overload: Python doesn't have a stringstream equivalent
-      //  .def("Restore", nb::overload_cast<std::istringstream&>(&MetadataSingleTag::Restore),
+      // Omitting the std::istringstream& overload: Python doesn't have a
+      // stringstream equivalent
+      //  .def("Restore",
+      //  nb::overload_cast<std::istringstream&>(&MetadataSingleTag::Restore),
       //  "istream"_a, "Restores from an input stream")
-      .def("Restore", nb::overload_cast<const char*>(&MetadataSingleTag::Restore), "stream"_a,
+      .def("Restore", nb::overload_cast<const char *>(&MetadataSingleTag::Restore), "stream"_a,
            "Restores from a serialized string");
 
   nb::class_<MetadataArrayTag, MetadataTag>(m, "MetadataArrayTag")
       .def(nb::init<>(), "Default constructor")
-      .def(nb::init<const char*, const char*, bool>(), "name"_a, "device"_a, "readOnly"_a,
+      .def(nb::init<const char *, const char *, bool>(), "name"_a, "device"_a, "readOnly"_a,
            "Parameterized constructor")
-      .def("ToArrayTag", &MetadataArrayTag::ToArrayTag, "Returns this object as MetadataArrayTag")
+      .def("ToArrayTag", &MetadataArrayTag::ToArrayTag,
+           "Returns this object as MetadataArrayTag")
       .def("AddValue", &MetadataArrayTag::AddValue, "val"_a, "Adds a value to the array")
       .def("SetValue", &MetadataArrayTag::SetValue, "val"_a, "idx"_a,
            "Sets a value at a specific index")
@@ -539,10 +597,12 @@ NB_MODULE(_pymmcore_nano, m) {
       .def("GetSize", &MetadataArrayTag::GetSize, "Returns the size of the array")
       .def("Clone", &MetadataArrayTag::Clone, "Clones this tag")
       .def("Serialize", &MetadataArrayTag::Serialize, "Serializes this tag to a string")
-      // Omitting the std::istringstream& overload: Python doesn't have a stringstream equivalent
-      //  .def("Restore", nb::overload_cast<std::istringstream&>(&MetadataArrayTag::Restore),
+      // Omitting the std::istringstream& overload: Python doesn't have a
+      // stringstream equivalent
+      //  .def("Restore",
+      //  nb::overload_cast<std::istringstream&>(&MetadataArrayTag::Restore),
       //       "istream"_a, "Restores from an input stream")
-      .def("Restore", nb::overload_cast<const char*>(&MetadataArrayTag::Restore), "stream"_a,
+      .def("Restore", nb::overload_cast<const char *>(&MetadataArrayTag::Restore), "stream"_a,
            "Restores from a serialized string");
 
   nb::class_<MMEventCallback, PyMMEventCallback>(m, "MMEventCallback")
@@ -561,34 +621,34 @@ NB_MODULE(_pymmcore_nano, m) {
            "Called when the system configuration is loaded")
       .def("onPixelSizeChanged", &MMEventCallback::onPixelSizeChanged, "newPixelSizeUm"_a,
            "Called when the pixel size changes")
-      .def("onPixelSizeAffineChanged", &MMEventCallback::onPixelSizeAffineChanged, "v0"_a, "v1"_a,
-           "v2"_a, "v3"_a, "v4"_a, "v5"_a,
+      .def("onPixelSizeAffineChanged", &MMEventCallback::onPixelSizeAffineChanged, "v0"_a,
+           "v1"_a, "v2"_a, "v3"_a, "v4"_a, "v5"_a,
            "Called when the pixel size affine transformation changes")
-      // These bindings are ugly lambda workarounds because the original methods take char* instead
-      // of const char*
+      // These bindings are ugly lambda workarounds because the original methods
+      // take char* instead of const char*
       // https://github.com/micro-manager/mmCoreAndDevices/pull/530
       .def(
           "onSLMExposureChanged",
-          [](MMEventCallback& self, const std::string& name, double newExposure) {
-            self.onSLMExposureChanged(const_cast<char*>(name.c_str()), newExposure);
+          [](MMEventCallback &self, const std::string &name, double newExposure) {
+            self.onSLMExposureChanged(const_cast<char *>(name.c_str()), newExposure);
           },
           "name"_a, "newExposure"_a)
       .def(
           "onExposureChanged",
-          [&](MMEventCallback& self, const std::string& name, double newExposure) {
-            self.onExposureChanged(const_cast<char*>(name.c_str()), newExposure);
+          [&](MMEventCallback &self, const std::string &name, double newExposure) {
+            self.onExposureChanged(const_cast<char *>(name.c_str()), newExposure);
           },
           "name"_a, "newExposure"_a)
       .def(
           "onStagePositionChanged",
-          [&](MMEventCallback& self, const std::string& name, double pos) {
-            self.onStagePositionChanged(const_cast<char*>(name.c_str()), pos);
+          [&](MMEventCallback &self, const std::string &name, double pos) {
+            self.onStagePositionChanged(const_cast<char *>(name.c_str()), pos);
           },
           "name"_a, "pos"_a)
       .def(
           "onXYStagePositionChanged",
-          [&](MMEventCallback& self, const std::string& name, double xpos, double ypos) {
-            self.onXYStagePositionChanged(const_cast<char*>(name.c_str()), xpos, ypos);
+          [&](MMEventCallback &self, const std::string &name, double xpos, double ypos) {
+            self.onXYStagePositionChanged(const_cast<char *>(name.c_str()), xpos, ypos);
           },
           "name"_a, "xpos"_a, "ypos"_a);
 
@@ -600,7 +660,8 @@ NB_MODULE(_pymmcore_nano, m) {
   // because this is far simpler... but we could expose more if needed
   // this will expose pymmcore_nano.CMMErrors as a subclass of RuntimeError
   // and a basic message will be propagated, for example:
-  // CMMError('Failed to load device "SomeDevice" from adapter module "SomeModule"')
+  // CMMError('Failed to load device "SomeDevice" from adapter module
+  // "SomeModule"')
   nb::exception<CMMError>(m, "CMMError", PyExc_RuntimeError);
   nb::exception<MetadataKeyError>(m, "MetadataKeyError", PyExc_KeyError);
   nb::exception<MetadataIndexError>(m, "MetadataIndexError", PyExc_IndexError);
@@ -824,7 +885,14 @@ NB_MODULE(_pymmcore_nano, m) {
       .def("isMultiROISupported", &CMMCore::isMultiROISupported)
       .def("isMultiROIEnabled", &CMMCore::isMultiROIEnabled)
       .def("setMultiROI", &CMMCore::setMultiROI, "xs"_a, "ys"_a, "widths"_a, "heights"_a)
-      .def("getMultiROI", &CMMCore::getMultiROI, "xs"_a, "ys"_a, "widths"_a, "heights"_a)
+      .def("getMultiROI",
+           [](CMMCore& self) -> std::tuple<std::vector<unsigned>, std::vector<unsigned>, std::vector<unsigned>,
+                                           std::vector<unsigned>> {
+                std::vector<unsigned> xs, ys, widths, heights;
+                    self.getMultiROI(xs, ys, widths, heights);
+                    return {xs, ys, widths, heights};
+           })
+
       .def("setExposure", nb::overload_cast<double>(&CMMCore::setExposure), "exp"_a)
       .def("setExposure", nb::overload_cast<const char*, double>(&CMMCore::setExposure),
            "cameraLabel"_a, "dExp"_a)
@@ -1056,11 +1124,20 @@ NB_MODULE(_pymmcore_nano, m) {
            "xyStageLabel"_a, "dx"_a, "dy"_a)
       .def("setRelativeXYPosition",
            nb::overload_cast<double, double>(&CMMCore::setRelativeXYPosition), "dx"_a, "dy"_a)
+
       .def("getXYPosition",
-           nb::overload_cast<const char*, double&, double&>(&CMMCore::getXYPosition),
-           "xyStageLabel"_a, "x_stage"_a, "y_stage"_a)
-      .def("getXYPosition", nb::overload_cast<double&, double&>(&CMMCore::getXYPosition),
-           "x_stage"_a, "y_stage"_a)
+           [](CMMCore& self, const char* xyStageLabel) -> std::tuple<double, double> {
+             double x, y;
+             self.getXYPosition(xyStageLabel, x, y);
+             return {x, y};
+           },
+           "xyStageLabel"_a)
+          .def("getXYPosition",
+               [](CMMCore& self) -> std::tuple<double, double> {
+               double x, y;
+               self.getXYPosition(x, y);
+               return {x, y};
+               })
       .def("getXPosition", nb::overload_cast<const char*>(&CMMCore::getXPosition),
            "xyStageLabel"_a)
       .def("getYPosition", nb::overload_cast<const char*>(&CMMCore::getYPosition),

--- a/src/_pymmcore_nano.pyi
+++ b/src/_pymmcore_nano.pyi
@@ -12,6 +12,13 @@ class ActionType(enum.IntEnum):
     StartSequence = 5
     StopSequence = 6
 
+AfterLoadSequence: int = 4
+AfterSet: int = 2
+AnyType: int = 1
+Attention: int = 0
+AutoFocusDevice: int = 9
+BeforeGet: int = 1
+
 class CMMCore:
     def __init__(self) -> None: ...
     def loadSystemConfiguration(self, fileName: object) -> None: ...
@@ -209,13 +216,7 @@ class CMMCore:
         widths: Sequence[int],
         heights: Sequence[int],
     ) -> None: ...
-    def getMultiROI(
-        self,
-        xs: Sequence[int],
-        ys: Sequence[int],
-        widths: Sequence[int],
-        heights: Sequence[int],
-    ) -> None: ...
+    def getMultiROI(self) -> tuple[list[int], list[int], list[int], list[int]]: ...
     @overload
     def setExposure(self, exp: float) -> None: ...
     @overload
@@ -416,11 +417,9 @@ class CMMCore:
     @overload
     def setRelativeXYPosition(self, dx: float, dy: float) -> None: ...
     @overload
-    def getXYPosition(
-        self, xyStageLabel: str, x_stage: float, y_stage: float
-    ) -> None: ...
+    def getXYPosition(self, xyStageLabel: str) -> tuple[float, float]: ...
     @overload
-    def getXYPosition(self, x_stage: float, y_stage: float) -> None: ...
+    def getXYPosition(self) -> tuple[float, float]: ...
     @overload
     def getXPosition(self, xyStageLabel: str) -> float: ...
     @overload
@@ -521,12 +520,17 @@ class CMMCore:
 class CMMError(RuntimeError):
     pass
 
+CameraDevice: int = 2
+CanCommunicate: int = 1
+CanNotCommunicate: int = 0
+
 class Configuration:
     def __init__(self) -> None: ...
     def addSetting(self, setting: PropertySetting) -> None: ...
     def deleteSetting(self, device: str, property: str) -> None: ...
     def isPropertyIncluded(self, device: str, property: str) -> bool: ...
     def isConfigurationIncluded(self, cfg: Configuration) -> bool: ...
+    def isSettingIncluded(self, setting: PropertySetting) -> bool: ...
     @overload
     def getSetting(self, index: int) -> PropertySetting: ...
     @overload
@@ -534,6 +538,7 @@ class Configuration:
     def size(self) -> int: ...
     def getVerbose(self) -> str: ...
 
+CoreDevice: int = 10
 DEVICE_BUFFER_OVERFLOW: int = 22
 DEVICE_CAMERA_BUSY_ACQUIRING: int = 30
 DEVICE_CAN_NOT_SET_PROPERTY: int = 32
@@ -614,10 +619,27 @@ class DeviceType(enum.IntEnum):
     HubDevice = 15
     GalvoDevice = 16
 
+Done: int = 1
+Float: int = 2
+
 class FocusDirection(enum.IntEnum):
     FocusDirectionUnknown = 0
     FocusDirectionTowardSample = 1
     FocusDirectionAwayFromSample = 2
+
+FocusDirectionAwayFromSample: int = 2
+FocusDirectionTowardSample: int = 1
+FocusDirectionUnknown: int = 0
+GalvoDevice: int = 16
+GenericDevice: int = 8
+HIDPort: int = 3
+HubDevice: int = 15
+ImageProcessorDevice: int = 11
+InitializationFailed: int = 2
+InitializedSuccessfully: int = 1
+Integer: int = 3
+InvalidPort: int = 0
+IsSequenceable: int = 3
 
 class MMEventCallback:
     def __init__(self) -> None: ...
@@ -644,6 +666,7 @@ class MMEventCallback:
 
 MM_CODE_ERR: int = 1
 MM_CODE_OK: int = 0
+MagnifierDevice: int = 13
 
 class Metadata:
     @overload
@@ -755,6 +778,9 @@ class MetadataTag:
     def Restore(self, stream: str) -> bool:
         """Restores from a serialized string"""
 
+Misconfigured: int = -1
+NoAction: int = 0
+
 class PortType(enum.IntEnum):
     InvalidPort = 0
     SerialPort = 1
@@ -794,6 +820,23 @@ class PropertyType(enum.IntEnum):
     Float = 2
     Integer = 3
 
+SLMDevice: int = 14
+SerialDevice: int = 7
+SerialPort: int = 1
+ShutterDevice: int = 3
+SignalIODevice: int = 12
+StageDevice: int = 5
+StartSequence: int = 5
+StateDevice: int = 4
+StatusChanged: int = 2
+StopSequence: int = 6
+String: int = 1
+USBPort: int = 2
+Undef: int = 0
+Unimplemented: int = -2
+Uninitialized: int = 0
+UnknownType: int = 0
+XYStageDevice: int = 6
 g_CFGCommand_ConfigGroup: str = "ConfigGroup"
 g_CFGCommand_ConfigPixelSize: str = "ConfigPixelSize"
 g_CFGCommand_Configuration: str = "Config"

--- a/src/pymmcore_nano/__init__.py
+++ b/src/pymmcore_nano/__init__.py
@@ -1,1 +1,29 @@
 from _pymmcore_nano import *  # noqa
+
+import sys
+import importlib.util
+
+from importlib.metadata import version, PackageNotFoundError
+
+
+try:
+    __version__ = version("pymmcore-nano")
+except PackageNotFoundError:
+    __version__ = "uninstalled"
+
+_pymmcore_spec = importlib.util.find_spec("pymmcore")
+
+
+class PymmcoreRedirect:
+    def find_spec(self, fullname, path, target=None):
+        if fullname == "pymmcore_swig":
+            # Redirect to the replacement package
+            return _pymmcore_spec
+        if fullname == "pymmcore":
+            # Redirect to the replacement package
+            return importlib.util.find_spec("pymmcore_nano")
+        return None
+
+
+def patch_pymmcore():
+    sys.meta_path.insert(0, PymmcoreRedirect())

--- a/src/pymmcore_nano/__init__.py
+++ b/src/pymmcore_nano/__init__.py
@@ -15,6 +15,8 @@ _pymmcore_spec = importlib.util.find_spec("pymmcore")
 
 
 class PymmcoreRedirect:
+    """Redirects imports of `pymmcore` to `pymmcore_nano`."""
+
     def find_spec(self, fullname, path, target=None):
         if fullname == "pymmcore_swig":
             # Redirect to the replacement package
@@ -26,4 +28,5 @@ class PymmcoreRedirect:
 
 
 def patch_pymmcore():
+    """Add a meta path hook to redirect imports of `pymmcore` to `pymmcore_nano`."""
     sys.meta_path.insert(0, PymmcoreRedirect())


### PR DESCRIPTION
This PR adds stuff that makes pymmcore-nano more of a drop-in replacement for pymmcore.  With this PR, I can run the entire test suite of pymmcore-plus with only a couple small errors (after a few small backwards changes in pymmcore-plus that are cross-compatible)

one of the most notable changes has to do with ownership of numpy arrays (#14).  I'm still not sure I'm doing it correctly..
I added some comments in the source code for `create_image_array` about the various methods I've tried and what they resulted in

### Configuration Updates:
* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L16-R19): Updated the `clang-format` style to use a `ColumnLimit` of 96 and bumped the `ruff-pre-commit` version to `v0.8.1`.

### Build Process Enhancements:
* [`meson.build`](diffhunk://#diff-30d8f6be6320feeacf686be94f48c70869b52630e01ea625f0f15adc0d57c3e4L43-R43): Added `-DMATCH_SWIG` to `cpp_args` and included `-DNB_DOMAIN=pmn` for the `ext_module`. [[1]](diffhunk://#diff-30d8f6be6320feeacf686be94f48c70869b52630e01ea625f0f15adc0d57c3e4L43-R43) [[2]](diffhunk://#diff-30d8f6be6320feeacf686be94f48c70869b52630e01ea625f0f15adc0d57c3e4L55-R55)

### Code Refactoring and Documentation:
* [`src/_pymmcore_nano.cc`](diffhunk://#diff-fc2359e6c90f40eec6e64cd7cbda5a07868f0ef7134a5045150d5ccc06d4e2d4L21-R22): Refactored the `get_dtype_shape` function for improved readability and updated the `create_image_array` and `create_metadata_array` functions to handle ownership issues more effectively. Added detailed comments and notes regarding memory management and potential pitfalls. [[1]](diffhunk://#diff-fc2359e6c90f40eec6e64cd7cbda5a07868f0ef7134a5045150d5ccc06d4e2d4L21-R22) [[2]](diffhunk://#diff-fc2359e6c90f40eec6e64cd7cbda5a07868f0ef7134a5045150d5ccc06d4e2d4L49-R53) [[3]](diffhunk://#diff-fc2359e6c90f40eec6e64cd7cbda5a07868f0ef7134a5045150d5ccc06d4e2d4L69-R86) [[4]](diffhunk://#diff-fc2359e6c90f40eec6e64cd7cbda5a07868f0ef7134a5045150d5ccc06d4e2d4L98-R167) [[5]](diffhunk://#diff-fc2359e6c90f40eec6e64cd7cbda5a07868f0ef7134a5045150d5ccc06d4e2d4L157-R183) [[6]](diffhunk://#diff-fc2359e6c90f40eec6e64cd7cbda5a07868f0ef7134a5045150d5ccc06d4e2d4R228-R230) [[7]](diffhunk://#diff-fc2359e6c90f40eec6e64cd7cbda5a07868f0ef7134a5045150d5ccc06d4e2d4L343-L361) [[8]](diffhunk://#diff-fc2359e6c90f40eec6e64cd7cbda5a07868f0ef7134a5045150d5ccc06d4e2d4L396-L408) [[9]](diffhunk://#diff-fc2359e6c90f40eec6e64cd7cbda5a07868f0ef7134a5045150d5ccc06d4e2d4R428-R490) [[10]](diffhunk://#diff-fc2359e6c90f40eec6e64cd7cbda5a07868f0ef7134a5045150d5ccc06d4e2d4R499-R511) [[11]](diffhunk://#diff-fc2359e6c90f40eec6e64cd7cbda5a07868f0ef7134a5045150d5ccc06d4e2d4L472-R541) [[12]](diffhunk://#diff-fc2359e6c90f40eec6e64cd7cbda5a07868f0ef7134a5045150d5ccc06d4e2d4L499-R576)