### PR TITLE
test: no boost on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,10 @@ jobs:
         run: just install true true
 
       - name: test
-        run: uv run --no-editable pytest --color=yes -v --cov --cov-report=xml
+        run: uv run --no-sync pytest --color=yes -v --cov --cov-report=xml
 
       - name: cpp-coverage
-        run: uv run --no-editable gcovr --filter=src --xml coverage_cpp.xml --merge-mode-functions=merge-use-line-min
+        run: uv run --no-sync gcovr --filter=src --xml coverage_cpp.xml --merge-mode-functions=merge-use-line-min
 
       - uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
         with:
           toolset: "14.29"
       
-      - name: install boost
-        if: matrix.platform == 'windows-latest'
-        run: choco install boost-msvc-14.2
+      # - name: install boost
+      #   if: matrix.platform == 'windows-latest'
+      #   run: choco install boost-msvc-14.2
 
       - name: install
         # install with devices=true coverage=true

--- a/README.md
+++ b/README.md
@@ -64,8 +64,11 @@ just install
 
 This repo contains a few device adapters that are useful for testing,
 in src/mmCoreAndDevices/DeviceAdapters.  These adapters are built as a part of the
-installation.  On windows, you will also need boost installed (e.g.
-`choco install boost-msvc-14.3`, or similar version according to your version of visual studio)
+installation.  
+
+On windows, in order to build the SequenceTester device (optional) you will also
+need boost installed (e.g. `choco install boost-msvc-14.3`, or similar version
+according to your version of visual studio)
 
 ### Test
 

--- a/src/mmCoreAndDevices/DeviceAdapters/meson.build
+++ b/src/mmCoreAndDevices/DeviceAdapters/meson.build
@@ -1,4 +1,8 @@
 subdir('DemoCamera')
 subdir('Utilities')
-subdir('SequenceTester')
 subdir('NotificationTester')
+# leaving this out by default for now because 
+# windows is slow to get boost and this requires it
+if host_machine.system() != 'windows'
+  subdir('SequenceTester')
+endif


### PR DESCRIPTION
don't build SequenceTester (and therefore don't require boost) on windows